### PR TITLE
Use address line when no other address details are available.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ tests/e2e/screenshots
 selenium-debug.log
 
 !.gitkeep
+/build/config/*-custom.json5

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -294,10 +294,11 @@ export function getPatientEmail(patient = {}) {
 export function getPatientHomeAddress(patient = {}) {
     let a = (patient.address || []);
     a = a.find(c => c.use == "home") || a[0] || {};
-    return [a.line, a.postalCode, a.city, a.country]
+    var l = [a.line, a.postalCode, a.city, a.country]
         .map(x => String(x || "").trim())
         .filter(Boolean)
         .join(" ");
+    return l ? l : a.text || "";
 }
 
 /**


### PR DESCRIPTION
If the text representation of the address is available but no other address details, at least the text representation should be shown.