### PR TITLE
Trim parameters before compiling PatientSearch

### DIFF
--- a/src/lib/PatientSearch.js
+++ b/src/lib/PatientSearch.js
@@ -486,10 +486,14 @@ export default class PatientSearch
         else {
 
             // Custom params ---------------------------------------------------
-            Object.keys(this.params).forEach(k => params.push({
-                name : k,
-                value: this.params[k]
-            }))
+            Object.keys(this.params).forEach(k => {
+                if(this.params[k].trim()) {
+                    params.push({
+                        name : k,
+                        value: this.params[k]
+                    });
+                }
+            });
 
             // sort ------------------------------------------------------------
             if (this.sort) {


### PR DESCRIPTION
When testing with some FHIR servers (especially HAPI R4), passing a search query with name="" return no results instead of all results.

I've added a trim on empty parameters before doing the search.